### PR TITLE
Create an `is_child` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ This is an array of devices recognized (paired with) by the coordinator. Every i
 The primary reason for this array is storage of APS encryption unique link keys, which may be required by devices using APS security.
 
 Every object within this array contains the following fields:
-* `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
+* `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes) (`null ` if unknown),
 * `ieee_address`: *string* - 64-bit IEEE address of the device encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
+* `is_child`: *boolean* (optional) - whether or not the device entry is for a child of the coordinator or for a partner device with an APS link key,
 * `link_key`: *object* (optional),
    * `key`: *string* - 128-bit key encoded as described in [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
    * `rx_counter`: *number* - value of 32-bit receive frame counter for the link key,

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This is an array of devices recognized (paired with) by the coordinator. Every i
 The primary reason for this array is storage of APS encryption unique link keys, which may be required by devices using APS security.
 
 Every object within this array contains the following fields:
-* `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes) (`null ` if unknown),
+* `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
 * `ieee_address`: *string* - 64-bit IEEE address of the device encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
 * `is_child`: *boolean* (optional) - whether or not the device entry is for a child of the coordinator or for a partner device with an APS link key,
 * `link_key`: *object* (optional),

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The primary reason for this array is storage of APS encryption unique link keys,
 Every object within this array contains the following fields:
 * `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
 * `ieee_address`: *string* - 64-bit IEEE address of the device encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
-* `is_child`: *boolean* (optional) - indicates if the device is a child of the coordinator,
+* `is_child`: *boolean* (optional) - indicates if the device is a child of the coordinator (if not provided, consider it to be `false` if `link_key` is present and `true` otherwise),
 * `link_key`: *object* (optional),
    * `key`: *string* - 128-bit key encoded as described in [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
    * `rx_counter`: *number* - value of 32-bit receive frame counter for the link key,

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The primary reason for this array is storage of APS encryption unique link keys,
 Every object within this array contains the following fields:
 * `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
 * `ieee_address`: *string* - 64-bit IEEE address of the device encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
-* `is_child`: *boolean* (optional) - whether or not the device entry is for a child of the coordinator or for a partner device with an APS link key,
+* `is_child`: *boolean* (optional) - indicates if the device is a child of the coordinator,
 * `link_key`: *object* (optional),
    * `key`: *string* - 128-bit key encoded as described in [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
    * `rx_counter`: *number* - value of 32-bit receive frame counter for the link key,

--- a/schema.json
+++ b/schema.json
@@ -50,8 +50,9 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "nwk_address": {"type": "string", "pattern": "[a-fA-F0-9]{4}"},
+                    "nwk_address": {"type": ["string", "null"], "pattern": "[a-fA-F0-9]{4}"},
                     "ieee_address": {"type": "string", "pattern": "[a-fA-F0-9]{16}"},
+                    "is_child": {"type": "boolean"},
                     "link_key": {
                         "type": "object",
                         "properties": {

--- a/schema.json
+++ b/schema.json
@@ -50,7 +50,7 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "nwk_address": {"type": ["string", "null"], "pattern": "[a-fA-F0-9]{4}"},
+                    "nwk_address": {"type": "string", "pattern": "[a-fA-F0-9]{4}"},
                     "ieee_address": {"type": "string", "pattern": "[a-fA-F0-9]{16}"},
                     "is_child": {"type": "boolean"},
                     "link_key": {


### PR DESCRIPTION
It's not possible to currently tell if a device with an APS link key is a child or just a descendant. In Z-Stack, `is_child` would map to `AddrMgrUserType.Assoc`. The presence of `link_key` would indicate `AddrMgrUserType.Security`.

The current behavior is kept if the key is missing: assume `is_child == True` if no APS link key is present in the device entry, and `is_child == False` if there is an APS link key entry.