### PR TITLE
Update `is_child` description

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The primary reason for this array is storage of APS encryption unique link keys,
 Every object within this array contains the following fields:
 * `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
 * `ieee_address`: *string* - 64-bit IEEE address of the device encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
-* `is_child`: *boolean* (optional) - indicates if the device is a child of the coordinator (if not provided, consider it to be `false` if `link_key` is present and `true` otherwise),
+* `is_child`: *boolean* (optional) - indicates if the device is a child of the coordinator (if the field does not exist - consider `true`),
 * `link_key`: *object* (optional),
    * `key`: *string* - 128-bit key encoded as described in [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
    * `rx_counter`: *number* - value of 32-bit receive frame counter for the link key,


### PR DESCRIPTION
Hi @puddly,
I looked over the updated related to `is_child` key and I think we should consider the default value to be always `true` if the field is not provided (undefined). From what I understand the presence of `link_key` for the device has nothing to do with this and we should choose default value based on this.

The link key is always exchanged between device and coordinator agnostic of the number of routers in the way. So its presence does not give you grounds to determine default value for the `Assoc` flag. I think we should default to `true` since it does not seem to break the network and we cannot reliably determine its value if not explicitly provided.