### PR TITLE
Allow the `nwk_address` field to be `null`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This is an array of devices recognized (paired with) by the coordinator. Every i
 The primary reason for this array is storage of APS encryption unique link keys, which may be required by devices using APS security.
 
 Every object within this array contains the following fields:
-* `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
+* `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes). If a device's current 16-bit network is not known, the value `null` can be used.
 * `ieee_address`: *string* - 64-bit IEEE address of the device encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
 * `is_child`: *boolean* (optional) - indicates if the device is a child of the coordinator (if the field does not exist - consider `true`),
 * `link_key`: *object* (optional),

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ This is an array of devices recognized (paired with) by the coordinator. Every i
 The primary reason for this array is storage of APS encryption unique link keys, which may be required by devices using APS security.
 
 Every object within this array contains the following fields:
-* `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes). If a device's current 16-bit network is not known, the value `null` can be used.
 * `ieee_address`: *string* - 64-bit IEEE address of the device encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
+* `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes). If a device's current 16-bit network address is not known, the value `null` must be used.
 * `is_child`: *boolean* (optional) - indicates if the device is a child of the coordinator (if the field does not exist - consider `true`),
 * `link_key`: *object* (optional),
    * `key`: *string* - 128-bit key encoded as described in [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),

--- a/README.md
+++ b/README.md
@@ -97,11 +97,7 @@ This object contains vital information related to network key required to restor
 * `frame_counter`: *number* - numeric value of the 32-bit network frame counter.
 
 ### `devices`
-This is an array of devices recognized (paired with) by the coordinator. Every item maps network address to extended IEEE address of a device - which may be required by some adapters.
-
-The primary reason for this array is storage of APS encryption unique link keys, which may be required by devices using APS security.
-
-Every object within this array contains the following fields:
+This is an array of devices relevant to the coordinator: namely children and devices with APS link keys shared with the coordinator. Every object within this array contains the following fields:
 * `ieee_address`: *string* - 64-bit IEEE address of the device encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes),
 * `nwk_address`: *string* - 16-bit device network address encoded as per [Encoding Sequences of Bytes](#Encoding-Sequences-of-Bytes). If a device's current 16-bit network address is not known, the value `null` must be used.
 * `is_child`: *boolean* (optional) - indicates if the device is a child of the coordinator (if the field does not exist - consider `true`),

--- a/schema.json
+++ b/schema.json
@@ -50,7 +50,7 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "nwk_address": {"type": "string", "pattern": "[a-fA-F0-9]{4}"},
+                    "nwk_address": {"type": ["string", "null"], "pattern": "[a-fA-F0-9]{4}"},
                     "ieee_address": {"type": "string", "pattern": "[a-fA-F0-9]{16}"},
                     "is_child": {"type": "boolean"},
                     "link_key": {


### PR DESCRIPTION
EZSP coordinators don't really expose the NWK addresses of devices to the application so their backups are not guaranteed to have this information.

Surprisingly, it seems like we do not actually need to store them either.  I randomized all of the NWK addresses in a Z-Stack coordinator backup and after restoring it to my device, my network behavior did not change at all. I've been taking hourly coordinator backups for a while now and none of the NWK addresses in the backup have updated in over 24 hours now, even after a few coordinator resets. It appears that these NWK addresses are written only when a device joins the network and are not actually used at runtime.

We still need to provide dummy values for devices without known NWK addresses during restore but since Z-Stack is the only firmware that actually allows you to set them (neither EZSP or the Conbee firmware do), I suspect we may also be able to completely omit these keys as well (preserving `backup(state) == backup(restore(backup(state)))`).

Thoughts?